### PR TITLE
Production readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 RACK_ENV=development
 RAILS_LOG_TO_STDOUT=true
 SECRET_KEY_BASE=development_only_value_to_placate_secrets_yaml_file
+# WEB_CONCURRENCY=0 # Number of Puma processes to run. Use 0 for a tollerable `binding.pry` experience
+# WEB_DOMAIN="your-machine.local:5000" # Useful for testing iOS clients or web UI from other devices on the local network
+
+# App sepecific defaults
+DEFAULT_MAP_CENTER_LAT=33.7490 # Atlanta Georgia, USA
+DEFAULT_MAP_CENTER_LON=-84.3880
 
 # External services
-# GOOGLE_API_KEY=imma_s3kr3t # Only used in production-like environments
+GOOGLE_API_KEY=imma_s3kr3t
+RECAPTCHA_SECRET_KEY=imma_s3kr3t
+RECAPTCHA_SITE_KEY=imma_s3kr3t

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C ./config/puma.rb

--- a/README.md
+++ b/README.md
@@ -6,114 +6,102 @@ If you need help setting this platform up, please email me at brandon.cummings@b
 
 ## Introduction
 
-This platform was created for local cities or municipalities to help manage corona virus testing sites. This platform accomplishes 3 main goals:
+This platform was created for local cities or municipalities to help manage corona virus testing sites.
+This platform accomplishes 3 main goals:
 
-Questionnaire to self diagnose symptoms: If symptoms are present, the user will be shown a map that shows all local testing sites, and a google map link to direct them to the site.
-Testing site management: For all testing sites, there is a portal to keep track of number of tests administered and number of patients in line.
+#### Questionnaire to self diagnose symptoms
 
-Admin management: Full admin suite to create/edit testing site officials, testing sites, and a dashboard for analytics to gain real time insights.
+If symptoms are present, the user will be shown a map that shows all local testing sites, and a google map link to direct them to the site.
 
-## Proving the value of more testing centers:
+#### Testing site management
 
-Some local cities will not immediately see the need for more public testing centers and will need a digestible way of analyzing this solution, so we created a slide deck to explain why cities should implement this platform.
+For all testing sites, there is a portal to keep track of number of tests administered and number of patients in line.
 
-https://docs.google.com/presentation/d/1dOQSBMMUycuwKto4_SnoCBAIxSTDLVvGNfzxb64Z7nI/edit#slide=id.p
+#### Admin management
 
-## Table Of Contents
+Full admin suite to create/edit testing site officials, testing sites, and a dashboard for analytics to gain real time insights.
 
-1. Domain registration
-2. Hosting setup
-3. Google Maps API setup
-4. Sendgrid setup
-5. App setup
-6. Recaptcha Setup
-7. Example usage
-8. Environment Variables
+#### Proving the value of more testing centers:
 
-## Domain registration
+Some local cities will not immediately see the need for more public testing centers and will need a digestible way of analyzing this solution.
+To aide with that, we created a [slide deck to explain why cities should implement this platform][deck].
 
-I highly recommend not using GoDaddy to register your domain, you need to use a domain manager that allows you to update A records without having a static IP address, such as https://dnsimple.com/.
+## Hosting and Deploying
 
-Go purchase a domain, such as the domain we purchased: atlanta-covid19-testing-sites.com
+Please see the [self hosting guide](docs/self-hosting.md).
 
-Once you have registered this domain, we will revisit to connect heroku site and to prove to google you are the owner by adding CNAME records.
+## 🏎 Getting up and Running
 
-## Hosting setup
+Because installing dependencies is such a pain, we've bootstrapped this thing for you!
 
-I highly recommend using Heroku, it’s very easy to get setup.
+```bash
+bin/setup
 
-Heroku signup: https://signup.heroku.com/t/platform
+# for all options:
 
-Setup the heroku app and prepare an app to push to from your command line. Head to your settings of this app you just created, select “Reveal Config Vars” these are all environment variables for you application.
-Save RAILS_APP_ROOT_DOMAIN as the root domain you just purchased.
+bin/setup -h
+```
 
-## Google Maps API setup
+being sure to follow any instructions it gives you.
+After you've done that you should have:
 
-The google maps api is a crucial part of this application, so please follow these steps:
+* the following soft dependencies installed: PostgreSQL, Heroku Toolbelt, etc...
+* the correct version of Ruby installed and activated
+* hard dependencies (via `Gemfile`) installed
+* a local `.env` file for setting ENV Vars
+* databases created w/schemas loaded for both `development` and `test` environments.
+* seed `development` databases
 
-Go to https://console.developers.google.com/
-1. Create a new project called “COVID19-Testing”
-2. Enable the Google Maps Javascript API
-3. You will need to have a verified domain in order to create credentials, create a verified domain by following the steps.
-4. Visit https://console.developers.google.com/apis/credentials/domainverification Follow the steps provided, I had to add a CNAME record to my DNS that pointed to the value google provided
-5. Create API credentials, which will produce an API key that you should keep safe and never 	  store publicly, only store within environment variables.
-6. Restrict your API key to only the Google Maps Javascript API and add the urls that you purchased, so only those urls can access your application. In our case we added the following urls:
+#### 🗂 ENV Vars
 
-    https://www.atlanta-covid19-testing-sites.com
-    https://atlanta-covid19-testing-sites.com
-    http://localhost:3000 (for developing locally)
+You can set some *optional* [ENV Vars][env-vars] to tweak the way the app runs, or simulate the app running on other platforms.
+In development and test, you should configure these via a [`.env` file][dotenv].
 
-Once you have your API key, save it to your heroku apps settings, under the “Reveal Config Vars”, and add it as GOOGLE_API_KEY.
+  - `DATABASE_URL`: set to mimic the behavior of setting the database connection on Heroku. *(Default to using `config/database.yml`)*
+  - `DB_REAPING_FREQUENCY`: how often (in seconds) the database connection pool should be reaped. _(Default = `10`)_
+  - `WEB_CONCURRENCY`: set the number of [Puma][puma] worker process to run. *(Default = `2`)*
+  - `RAILS_MAX_THREADS`: set the number of [Puma][puma] threads & ActiveRecord's connection pool size. *(Default = `5`)*
 
-## Sendgrid Setup
+There are also some **required** [ENV Vars][env-vars] that you'll need to set for all environments.
 
-Go to https://sendgrid.com/ and signup. Go to https://app.sendgrid.com/settings/api_keys to setup an API key with full access.
+  - `GOOGLE_API_KEY`: the API key used to render Google Maps.
+  - `RECAPTCHA_SECRET_KEY` and `RECAPTCHA_SITE_KEY`: used to render the reCAPTCHA element on index page.
+      RECAPTCHA_SITE_KEY
 
-Save this API key in your heroku config vars as SEND_GRID_API_KEY
-Also save to your heroku config vars SEND_GRID_USERNAME with the value of “apikey” (literally the word “apikey” not your actual API key)
+Further there are some **required** [ENV Vars][env-vars] that you'll need to set in `production`.
+These are covered in more detail in the [self-hosting docs](docs/self-hosting.md).
+These can also be overridden in local `development` and `test` environments via your `.env` file.
 
-## App setup
+  - `DEFAULT_MAP_CENTER_LAT`: the latitude of the default center of your map
+  - `DEFAULT_MAP_CENTER_LON`: the longitude of the default center of your map
+  - `RAILS_APP_ROOT_DOMAIN`: the HTTP host to use when generating URLS for emails, assets, etc... *(Default = `localhost:5000`)*
+  - `SEND_GRID_API_KEY` and `SEND_GRID_USERNAME`: for sending emails.
 
-Fork this repo so that you can push any changes to your own custom repository.
+#### ⚗️ Development data
 
-Once pulled down, run:
+### 🏁 Running the app
 
-rake db:create
+We use a [`Procfile`][procfile] to declare all of the processes we use.
+This includes starting the Rails app (via the [Puma][puma] web server).
+Use [Heroku-local][heroku-local] to start/stop all of the processes in the `Procfile`:
 
-Here is a great resource to get rails up and running: https://www.tutorialspoint.com/ruby-on-rails/rails-installation.htm
+```bash
+heroku local:start
+```
 
-Once you have the repo, follow these steps:
+*NOTE: You can shut everything down by hitting `^C` _(that's `Control` + `C`)_.*
 
-1. bundle install
-2. rake db:create db:migrate
-3. Store your environment variables, from your command line write:
-4. export GOOGLE_API_KEY=<api_key_you_created>
-5. export RECAPTCHA_SITE_KEY=<recaptcha site key>
-6. export RECAPTCHA_SECRET_KEY=<recaptcha secret key>
+Point your browser/client at <http://localhost:5000> to see the app in action!
 
-Run the app locally by running “rails s”, then visit http://localhost:3000 on your local machine and browser of choice.
+With the app running, you should be able to sign in with the seeded admin account `admin@example.com` and the password `password1234`.
 
-In order to see the Site Official View, you will need to create a new User and Host through the Admin view, and in order to view the admin view at http://localhost:3000/admin you will need to create a new AdminUser.
+In order to see the Site Official View, you will need to create a new User and Host through the [Admin view](http://localhost:5000/admin).
 
-1. Run “rails c” to run the rails console
-2. Then create a new AdminUser by running “AdminUser.create(email: “example@gmail.com”, password: “password”)
-3. Then visit http://localhost:3000/admin, sign in with the email and password created.
-4. You can then go to the tab “Testing Sites” and “Location Officials” to create a new Host and User.
-5. The User your create must be associated to a Host, and make sure the host address is correctly populated by Geocoder by  checking the fields “latitude” and “longitude”, if the address is correct, those fields should be populated correctly.
+1. Go to the “Testing Sites” tab to create a new Host.
+1. Go to the “Location Officials” tab and create a new User.
 
-You will most likely run into some issues with setup, most can be googled and have been addressed, stay patient and you will get through it.
-
-## Recaptcha Setup
-
-Recaptcha is used to prevent bots from overwhelming your site and wasting you google maps API calls by implementing a simple checkbox that says "I am not a robot".
-
-To setup, visit https://www.google.com/recaptcha/admin/create
-
-Choose V2 "Checkbox"
-
-Input the domains you have purchased.
-
-Save RECATPCHA_SITE_KEY and RECATPCHA_SECRET_KEY as environment variables on your heroku instance.
+    _NOTE:_ The User your create must be associated to the Host you just created.
+    Also be sure the host address is correctly populated by Geocoder by checking the fields “latitude” and “longitude”.
 
 ## Example usage
 
@@ -121,23 +109,23 @@ This platform can be used the following way.
 
 A local government IT team sets up the platform and designates where in the city a testing site will be located and how many officials will work at each location.
 
-Citizen View: The city will market to the citizens the url of the site, the citizen can self diagnose symptoms and find a testing site if needed.
+#### Citizen View
 
-Testing Site Officials View: there are two main actions that can occur in the testing site officials view, increasing the number of test kits used, and keeping track of people in line waiting to receive a test kit.
+The city will market to the citizens the url of the site, the citizen can self diagnose symptoms and find a testing site if needed.
+
+#### Testing Site Officials View
+
+There are two main actions that can occur in the testing site officials view, increasing the number of test kits used, and keeping track of people in line waiting to receive a test kit.
 
 If there are 3 individuals working a testing site, one can be administering the test, one can be capturing the patient information and updating the number of test kits used through the platform, and one can be keeping the line count up to date and organized.
 
-Admin View: The admin view allows for new testing sites and testing site officials to be created/updated, as well as showing in real time the number of test kits used, total wait time and testing sites that may need additional resources, per testing site.
+#### Admin View
 
-## Environment Variables
+The admin view allows for new testing sites and testing site officials to be created/updated, as well as showing in real time the number of test kits used, total wait time and testing sites that may need additional resources, per testing site.
 
-The environment variables needed to be set in heroku are as follows:
-
-1. GOOGLE_API_KEY - your Google Maps Javascript api key
-2. DEFAULT_MAP_CENTER_LAT - the latitude of the default center of your map
-3. DEFAULT_MAP_CENTER_LON - the longitude of the default center of your map
-4. RAILS_APP_ROOT_DOMAIN - root domain you are using
-5. SEND_GRID_USERNAME - which is "apikey" (the literal word "apikey")
-6. SEND_GRID_API_KEY - your sendgrid api key
-7. RECATPCHA_SECRET_KEY - Recaptcha secret key
-8. RECATPCHA_SITE_KEY - Recaptcha site key
+[deck]: https://docs.google.com/presentation/d/1dOQSBMMUycuwKto4_SnoCBAIxSTDLVvGNfzxb64Z7nI/edit#slide=id.p "Coronavirus Drive Through Testing Site Application"
+[dotenv]: https://github.com/bkeepers/dotenv "A Ruby gem to load environment variables from `.env`."
+[env-vars]: https://devcenter.heroku.com/articles/config-vars "Configuration and Config Vars"
+[heroku-local]: https://devcenter.heroku.com/articles/heroku-local "Heroku Local"
+[procfile]: https://devcenter.heroku.com/articles/procfile "Process Types and the Procfile"
+[puma]: http://puma.io/ "A modern, concurrent web server for Ruby"

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,85 +1,26 @@
-# PostgreSQL. Versions 9.1 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On OS X with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
-default: &default
+development: &default
   adapter: postgresql
+  database: corona_map_development
   encoding: unicode
+  host: localhost
+  min_messages: warning
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  reaping_frequency: <%= ENV.fetch("DB_REAPING_FREQUENCY", 10) %>
+  timeout: 5000
 
-development:
-  <<: *default
-  database: corona_map_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: corona_map
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
+test: &test
   <<: *default
   database: corona_map_test
+  pool: 5
+  reaping_frequency: 10
 
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 production:
-  <<: *default
-  database: corona_map_production
-  username: corona_map
-  password: <%= ENV['CORONA_MAP_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  encoding: unicode
+  min_messages: warning
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  reaping_frequency: <%= ENV.fetch("DB_REAPING_FREQUENCY", 10) %>
+  timeout: 5000
+  url: <%= ENV.fetch("DATABASE_URL", "") %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-  config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+  config.action_mailer.default_url_options = {host: "localhost", port: 5000}
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,5 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  config.action_mailer.default_url_options = {host: ENV["RAILS_APP_ROOT_DOMAIN"], port: 3000, protocol: "https", subdomain: "www"}
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,20 +3,16 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-#
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-threads threads_count, threads_count
+threads_count = Integer(ENV.fetch("RAILS_MAX_THREADS", 5))
+threads(threads_count, threads_count)
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+# Specifies the `port` that Puma will listen on to receive requests; default is 5000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 5000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
-
-# Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+environment ENV.fetch("RACK_ENV", "development")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
@@ -24,14 +20,35 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers Integer(ENV.fetch("WEB_CONCURRENCY", 2))
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
+
+# If you are preloading your application and using Active Record, it's
+# recommended that you close any connections to the database before workers
+# are forked to prevent connection leakage.
+#
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
+
+# The code in the `on_worker_boot` will be called if you are using
+# clustered mode by specifying a number of `workers`. After each worker
+# process is booted, this block will be run. If you are using the `preload_app!`
+# option, you will want to use this block to reconnect to any threads
+# or connections that may have been created at application boot, as Ruby
+# cannot share connections between processes.
+#
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,5 +4,5 @@
 # Examples:
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-AdminUser.create!(email: "admin@example.com", password: "password", password_confirmation: "password") if Rails.env.development?
+#   Character.create(name: 'Luke', movie: movies.first
+AdminUser.create!(email: "admin@example.com", password: "password1234", password_confirmation: "password1234") if Rails.env.development?

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,96 @@
+# Deploying your own instance
+
+This documentation explains how to set up your own instance of this tool.
+We prefer Heroku as the hosting platform, and the instructions are written from that angle.
+You can adjust to your own hosting preference as needed.
+
+## Table Of Contents
+
+1. [Domain Registration](#domain-registration)
+1. [Hosting Setup](#hosting-setup)
+1. [Google Maps API Setup](#google-maps-api-setup)
+1. [Sendgrid Setup](#sendgrid-setup)
+1. [Recaptcha Setup](#recaptcha-setup)
+1. [Environment Variables](#environment-variables)
+
+For local development instructions, please see the [`README`](../README.md).
+
+## Domain Registration
+
+We recommend a domain registrar and DNS provider that supports the `ALIAS`/`ANAME` record type.
+This is required to [configure your DNS for a root domain][dns-config], if you are using a hosting provider such as [Heroku][heroku].
+
+You probably want a domain that is specific to your municipality and/or geographical region. e.g., `atlanta-covid19-testing-sites.com`
+
+## Hosting Setup
+
+We recommend using [Heroku][heroku], it's easy to get setup.
+
+Setup the Heroku app and prepare an app to push to from your command line.
+Head to your settings of this app you just created, select “Reveal Config Vars” these are all environment variables for you application.
+Save `RAILS_APP_ROOT_DOMAIN` as the root domain you just purchased.
+
+## Google Maps API Setup
+
+The [Google Maps API][google-maps-api] is a crucial part of this application, so please follow these steps:
+
+1. Create a new project called “COVID19-Testing”
+1. Enable the Google Maps Javascript API
+1. You will need to have a verified domain in order to create credentials, create a verified domain by following the steps.
+
+    1. From the Google console, go to the [domain verification][google-domain-verification] page.
+    1. Follow the instructions, being sure to add a `CNAME` record to your DNS that points to the value Google gives you.
+
+1. Create Google Maps API credentials.
+
+    1. From the Google console, go to the "Credentials" tab.
+    1. Create a new key and store it somewhere safe.
+    **NEVER** store this key publicly, such as in your source code.
+    1. Restrict your API key to only the Google Maps Javascript API and add the domains that you purchased, so only those domains can access your application.
+    In our case we added the following urls:
+
+    ```
+    https://www.atlanta-covid19-testing-sites.com
+    https://atlanta-covid19-testing-sites.com
+    http://localhost:5000
+    ```
+
+    _NOTE:_ the `localhost:5000` is for local development testing.
+
+1. Open your Heroku app's Settings, then “Reveal Config Vars”, and add the Google Maps API key as `GOOGLE_API_KEY`.
+
+## Sendgrid Setup
+
+Go to [Sendgrid][sendgrid] and sign up.
+Then visit the [API Keys Settings][sendgrid-keys] to setup an API key with **full access**.
+
+Next, open your Heroku app's Settings, then “Reveal Config Vars”, and add the Sendgrid API Key with the name `SEND_GRID_API_KEY`.
+Also add a Heroku Config Var with the name `SEND_GRID_USERNAME` and a vlue of `apikey`.
+
+## Recaptcha Setup
+
+Recaptcha is used to prevent bots from overwhelming your site and wasting you Google Maps API calls by implementing a simple checkbox that says "I am not a robot".
+
+To set it up:
+
+1. Visit [reCAPTCHA setup].
+1. Choose V2 "Checkbox"
+1. Input the domains you have purchased.
+1. In your Heroku app's Settings, add the `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` Config Vars with the values from the reCAPTCHA setup.
+
+## Environment Variables
+
+The necessary and optional Environment Variables are described in the [`README`](../README.md#env-vars)
+
+## Up and Running
+
+With all of that done, you should be able to deploy your instance, and be up and running.
+Good luck!
+
+[dns-config]: https://devcenter.heroku.com/articles/custom-domains#configuring-dns-for-root-domains "Configuring DNS for root domains"
+[google-domain-verification]: https://console.developers.google.com/apis/credentials/domainverification
+[google-maps-api]: https://console.developers.google.com/ "Google Cloud Platform"
+[heroku]: https://heroku.com "Cloud Application Platform"
+[recaptcha]: https://www.google.com/recaptcha/admin/create
+[sendgrid-keys]: https://app.sendgrid.com/settings/api_keys
+[sendgrid]: https://sendgrid.com/


### PR DESCRIPTION
* Configure puma and db for production
    Leverage Heroku `Procfile` to have a single way to launch the app, including adding necessary ENV Vars, re-establishing ActiveRecord connections after puma boots, and looking for the `DATABASE_URL`, as is expected on Heroku.
* Document local dev vs deployment.
    We seed an admin user, so mention that in the README